### PR TITLE
Notify PLIP job runners

### DIFF
--- a/jobs.yml
+++ b/jobs.yml
@@ -374,6 +374,23 @@
             other-files:
                 - robot_*.png
 
+        - email-ext:
+            recipients: ${BUILD_USER_EMAIL}
+            reply-to:
+            content-type: default
+            always: true
+            failure: false
+            subject: "Jenkins PLIP {plip} [${BUILD_STATUS}]"
+            body: |
+                Dear ${BUILD_USER},
+
+                the Jenkins PLIP job for {plip} has finished:
+
+                ${BUILD_URL}
+
+                Yours truly,
+                Jenkins
+
     <<: *plone-xvfb
 
 


### PR DESCRIPTION
Send an email to whoever started a PLIP job with the job result.

This works the same way as the pull request job.

Fixes: https://github.com/plone/jenkins.plone.org/issues/87