### PR TITLE
Add Plone 5 JavaScript unittests

### DIFF
--- a/jobs.yml
+++ b/jobs.yml
@@ -88,6 +88,7 @@
         - 'plone-5.0-python-2.7'
         - 'plone-5.0-python-2.7-robot'
         - 'plone-5.0-python-2.7-at'
+        - 'plone-5.0-js'
 
 
 - project:
@@ -405,6 +406,40 @@
 
         - custom-archive:
             glob: 'parts/test/testreports/*.xml'
+
+    <<: *plone
+
+
+
+- job:
+    # Plone 5.0 JavaScript mockup unittests.
+    name: plone-5.0-js
+    display-name: 'Plone 5.0 - JavaScript'
+
+    scm:
+        - git:
+            url: git://github.com/plone/mockup.git
+            branches:
+                - 'master'
+            wipe-workspace: false
+            tag-builds: true
+            shallow-clone: true
+
+    builders:
+        - shell: |
+            echo $PATH
+            node --version
+            npm --version
+            make bootstrap
+            make test-jenkins
+
+    publishers:
+        - junit:
+            results: mockup/test-results.xml
+            keep-long-stdio: false
+
+    wrappers:
+        - custom-workspace-cleanup
 
     <<: *plone
 


### PR DESCRIPTION
Add a jenkins job to run mockup JavaScript unittests.

That's related to #108 and needs both https://github.com/plone/plone.jenkins_server/pull/17 and https://github.com/plone/plone.jenkins_node/pull/4 merged and running on production master and nodes to be actually useful.

I tried locally and it works (with Vagrant). It lacks reporting on Jenkins UI, but that can be solved later on, first we need to get something running and later make it useful :)