### PR TITLE
Do not pin setuptools to 8.3

### DIFF
--- a/jobs.yml
+++ b/jobs.yml
@@ -344,7 +344,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version=8.3 -c jenkins.cfg
+            $PYTHON27 bootstrap.py -c jenkins.cfg
             bin/buildout -c jenkins.cfg
             bin/alltests --xml
 
@@ -371,7 +371,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version=8.3 -c jenkins.cfg
+            $PYTHON27 bootstrap.py -c jenkins.cfg
             bin/buildout -c jenkins.cfg
             ROBOTSUITE_PREFIX=ONLYROBOT
             bin/alltests -t ONLYROBOT --all --xml
@@ -420,7 +420,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version=8.3 -c jenkins.cfg
+            $PYTHON27 bootstrap.py -c jenkins.cfg
             bin/buildout -c jenkins.cfg
             bin/alltests-at --xml
 
@@ -479,7 +479,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version=8.3 -c {buildout}
+            $PYTHON27 bootstrap.py -c {buildout}
             bin/buildout -c {buildout}
             bin/alltests --xml --all
             bin/alltests-at --xml
@@ -548,7 +548,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version=8.3 -c buildout.cfg
+            $PYTHON27 bootstrap.py -c buildout.cfg
             bin/buildout -c buildout.cfg
             bin/sphinx-build source build
 
@@ -757,11 +757,7 @@
             properties-file: vars.properties
 
         - shell: |
-            if [ "{plone-version}" = "4.3" ]; then
-                $PYTHON27 bootstrap.py -c jenkins.cfg
-            else
-                $PYTHON27 bootstrap.py --setuptools-version=8.3 -c jenkins.cfg
-            fi
+            $PYTHON27 bootstrap.py -c jenkins.cfg
             if [ "$PULL_REQUEST_PACKAGE_NAME" != "buildout.coredev" ]; then
                 sed -ie "s/^$PULL_REQUEST_PACKAGE_NAME\s.*/$PULL_REQUEST_PACKAGE_NAME = git git:\/\/github.com\/$PULL_REQUEST_FORK\/$PULL_REQUEST_PACKAGE_NAME.git branch=$PULL_REQUEST_BRANCH/g" sources.cfg
                 bin/buildout -c jenkins.cfg install add-package-to-auto-checkout
@@ -823,7 +819,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version 8.3 -c jenkins-package-dependencies.cfg
+            $PYTHON27 bootstrap.py -c jenkins-package-dependencies.cfg
             bin/buildout -c jenkins-package-dependencies.cfg
             bin/jenkins-package-dependencies-{kind}
             bin/jenkins-package-dependencies-{kind}-imports
@@ -848,7 +844,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version 8.3 -c jenkins-package-dependencies.cfg
+            $PYTHON27 bootstrap.py -c jenkins-package-dependencies.cfg
             bin/buildout -c jenkins-package-dependencies.cfg
             bin/jenkins-package-dependencies-text
 
@@ -887,7 +883,7 @@
             pre-commit-hook = False
             jenkins = True
             EOF
-            $PYTHON27 bootstrap.py --setuptools-version 8.3 -c jenkins.cfg
+            $PYTHON27 bootstrap.py -c jenkins.cfg
             bin/buildout -c jenkins.cfg
             bin/code-analysis
 
@@ -1052,7 +1048,7 @@
 
     builders:
         - shell: |
-            $PYTHON27 bootstrap.py --setuptools-version=8.3 -c release.cfg
+            $PYTHON27 bootstrap.py -c release.cfg
             bin/buildout -c release.cfg install releaser
             bin/manage jenkins > changelog.txt
 
@@ -1106,7 +1102,7 @@
             sed -i 's/^z3c./#z3c./' sources.cfg
             sed -i 's/^Products.CMF/#Products.CMF/' sources.cfg
             sed -i 's/^Products.MailHost/#Products.MailHost/' sources.cfg
-            $PYTHON27 bootstrap.py --setuptools-version=8.3 -c docs.cfg
+            $PYTHON27 bootstrap.py -c docs.cfg
             bin/buildout -c docs.cfg install test
 
         - python: |


### PR DESCRIPTION
Given that buildout.coredev is already handling setuptools +8.3 we can remove this from our jenkins jobs right?