### PR TITLE
Notify github pull requests

### DIFF
--- a/jobs.yml
+++ b/jobs.yml
@@ -705,6 +705,9 @@
         - shell:
             !include-raw: scripts/pr-tests.sh
 
+        - python:
+            !include-raw-escape: scripts/pr-update-status.py
+
     publishers:
         - custom-junit-new
 

--- a/scripts/pr-get-info.py
+++ b/scripts/pr-get-info.py
@@ -1,36 +1,133 @@
 # -*- coding: utf-8 -*-
+from github import Github
+from github.GithubException import BadCredentialsException
+from github.GithubException import UnknownObjectException
+
 import fileinput
-import json
 import os
 import re
 import sys
-import urllib2
 
-pull_request_urls = os.environ['PULL_REQUEST_URL']
 
 PKG_RE = r'^{0}\s.*'
 SOURCE_RE = r'{0} = git git://github.com/{1}/{0}.git branch={2}'
+PR_RE = r'https://github.com/(.*)/(.*)/pull/(.*)'
 
 PKGS = []
 COREDEV = 0
 
-for i, pr in enumerate(pull_request_urls.split()):
-    github_api_call = pr.replace('github.com', 'api.github.com/repos')
-    github_api_call = github_api_call.replace('/pull/', '/pulls/')
+try:
+    github_api_key = os.environ['GITHUB_API_KEY']
+except KeyError:
+    print(
+        '\n\n\n'
+        'GITHUB_API_KEY does not exist, pull request job can not run. '
+        '\n'
+        'Please contact the testing team: '
+        'https://github.com/orgs/plone/teams/testing-team'
+        '\n'
+        'Fill an issue as well: '
+        'https://github.com/plone/jenkins.plone.org/issues/new'
+        '\n\n\n'
+    )
+    sys.exit(1)
 
-    response = urllib2.urlopen(github_api_call)
-    json_data = json.loads(response.read())
+try:
+    pull_request_urls = os.environ['PULL_REQUEST_URL']
+except KeyError:
+    print(
+        '\n\n\n'
+        'You seem to forgot to add a pull request URL on the '
+        '"Build with parameters" form!'
+        '\n\n\n'
+    )
+    sys.exit(1)
 
-    org, branch = json_data['head']['label'].split(':')
-    pkg = json_data['base']['repo']['name']
+build_url = os.environ['BUILD_URL']
 
-    if pkg != 'buildout.coredev':
-        PKGS.append(pkg)
+g = Github(github_api_key)
+
+for pr in pull_request_urls.split():
+    org, repo, pr_number = re.search(PR_RE, pr).groups()
+
+    try:
+        pr_number = int(pr_number)
+    except ValueError:
+        msg = (
+            '\n\n\n'
+            'Error on trying to get info from Pull Request %s'
+            '\n'
+            'The pull request number "%s" is not a number!'
+            '\n\n\n'
+        )
+        print(msg % (pr, pr_number))
+        sys.exit(1)
+
+    # get the pull request organization it belongs to
+    try:
+        g_org = g.get_organization(org)
+    except BadCredentialsException:
+        print(
+            '\n\n\n'
+            'The API key used seems to not be valid any longer.'
+            '\n'
+            'Please contact the testing team: '
+            'https://github.com/orgs/plone/teams/testing-team'
+            '\n'
+            'Fill an issue as well: '
+            'https://github.com/plone/jenkins.plone.org/issues/new'
+            '\n\n\n'
+        )
+        sys.exit(1)
+    except UnknownObjectException:
+        msg = (
+            '\n\n\n'
+            'Error on trying to get info from Pull Request %s'
+            '\n'
+            'The organization "%s" does not seem to exist.'
+            '\n\n\n'
+        )
+        print(msg % (pr, org))
+        sys.exit(1)
+
+    # the repo where the pull request is from
+    try:
+        g_repo = g_org.get_repo(repo)
+    except UnknownObjectException:
+        msg = (
+            '\n\n\n'
+            'Error on trying to get info from Pull Request %s'
+            '\n'
+            'The repository "%s" does not seem to exist.'
+            '\n\n\n'
+        )
+        print(msg % (pr, repo))
+        sys.exit(1)
+
+    # the pull request itself
+    try:
+        g_pr = g_repo.get_pull(pr_number)
+    except UnknownObjectException:
+        msg = (
+            '\n\n\n'
+            'Error on trying to get info from Pull Request %s'
+            '\n'
+            'The pull request num "%s" does not seem to exist.'
+            '\n\n\n'
+        )
+        print(msg % (pr, pr_number))
+        sys.exit(1)
+
+    # get the branch
+    branch = g_pr.head.ref
+
+    if repo != 'buildout.coredev':
+        PKGS.append(repo)
         for line in fileinput.input('sources.cfg', inplace=True):
-            if line.find(pkg) != -1:
+            if line.find(repo) != -1:
                 line = re.sub(
-                    PKG_RE.format(pkg),
-                    SOURCE_RE.format(pkg, org, branch),
+                    PKG_RE.format(repo),
+                    SOURCE_RE.format(repo, org, branch),
                     line
                 )
             sys.stdout.write(line)

--- a/scripts/pr-get-info.py
+++ b/scripts/pr-get-info.py
@@ -121,6 +121,15 @@ for pr in pull_request_urls.split():
     # get the branch
     branch = g_pr.head.ref
 
+    # add a 'pending' status
+    last_commit = g_pr.get_commits().reversed[0]
+    last_commit.create_status(
+        u'pending',
+        target_url=build_url,
+        description='Job started, wait until it finishes',
+        context='Plone Jenkins CI',
+    )
+
     if repo != 'buildout.coredev':
         PKGS.append(repo)
         for line in fileinput.input('sources.cfg', inplace=True):

--- a/scripts/pr-update-status.py
+++ b/scripts/pr-update-status.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from github import Github
+from github.GithubException import BadCredentialsException
+from github.GithubException import UnknownObjectException
+
+import os
+import re
+import sys
+
+PR_RE = r'https://github.com/(.*)/(.*)/pull/(.*)'
+job_run_successfully = True
+
+# bare basic way to know if there was any test failure
+files = [f for f in os.listdir('parts/test/testreports/')]
+for f in files:
+    with open('parts/test/testreports/{0}'.format(f)) as xml_file:
+        first_line = xml_file.read().split('\n')[0]
+        failures = True
+        if first_line.find('failures="0"') != -1:
+            failures = False
+        errors = True
+        if first_line.find('errors="0"') != -1:
+            errors = False
+
+        if failures or errors:
+            job_run_successfully = False
+            break
+
+try:
+    github_api_key = os.environ['GITHUB_API_KEY']
+except KeyError:
+    print(
+        '\n\n\n'
+        'GITHUB_API_KEY does not exist, pull requests can not be updated. '
+        '\n'
+        'Please contact the testing team: '
+        'https://github.com/orgs/plone/teams/testing-team'
+        '\n'
+        'Fill an issue as well: '
+        'https://github.com/plone/jenkins.plone.org/issues/new'
+        '\n\n\n'
+    )
+    sys.exit(0)
+
+pull_request_urls = os.environ['PULL_REQUEST_URL']
+build_url = os.environ['BUILD_URL']
+g = Github(github_api_key)
+
+for pr in pull_request_urls.split():
+    org, repo, pr_number = re.search(PR_RE, pr).groups()
+
+    pr_number = int(pr_number)
+
+    # get the pull request organization it belongs to
+    try:
+        g_org = g.get_organization(org)
+    except BadCredentialsException:
+        print(
+            '\n\n\n'
+            'The API key used seems to not be valid any longer.'
+            '\n'
+            'Please contact the testing team: '
+            'https://github.com/orgs/plone/teams/testing-team'
+            '\n'
+            'Fill an issue as well: '
+            'https://github.com/plone/jenkins.plone.org/issues/new'
+            '\n\n\n'
+        )
+        sys.exit(0)
+    except UnknownObjectException:
+        msg = (
+            '\n\n\n'
+            'Error on trying to get info from Pull Request %s'
+            '\n'
+            'The organization "%s" does not seem to exist.'
+            '\n\n\n'
+        )
+        print(msg % (pr, org))
+        sys.exit(0)
+
+    # the repo where the pull request is from
+    try:
+        g_repo = g_org.get_repo(repo)
+    except UnknownObjectException:
+        msg = (
+            '\n\n\n'
+            'Error on trying to get info from Pull Request %s'
+            '\n'
+            'The repository "%s" does not seem to exist.'
+            '\n\n\n'
+        )
+        print(msg % (pr, repo))
+        sys.exit(0)
+
+    # the pull request itself
+    try:
+        g_pr = g_repo.get_pull(pr_number)
+    except UnknownObjectException:
+        msg = (
+            '\n\n\n'
+            'Error on trying to get info from Pull Request %s'
+            '\n'
+            'The pull request num "%s" does not seem to exist.'
+            '\n\n\n'
+        )
+        print(msg % (pr, pr_number))
+        sys.exit(0)
+
+    # get the branch
+    branch = g_pr.head.ref
+
+    # report back to github about how the job finished
+    last_commit = g_pr.get_commits().reversed[0]
+    status = u'success'
+    if not job_run_successfully:
+        status = u'error'
+
+    last_commit.create_status(
+        status,
+        target_url=build_url,
+        description=u'Job finished with %s status' % status,
+        context='Plone Jenkins CI',
+    )


### PR DESCRIPTION
Use the pre-script to notify the given pull request(s) that a jenkins
job has been started.

Do the same *after* the jenkins job has been running to let github
know if the run was successful or not.

Another building block to fully automate testing jenkins jobs for pull
requests.

Some caveats:
- it needs to be tested
- @tisto @svx it needs pygithub latest release on jenkins slaves, any objection to install it globally?
- there's no error handling at all, should a huge try...except be enough in this case (so, if anything fails still continue with it, or do not fail because github is unreachable/misbehaving)?