### PR TITLE
Point to the docs

### DIFF
--- a/scripts/pkg-qa-report.py
+++ b/scripts/pkg-qa-report.py
@@ -105,7 +105,7 @@ author = g_commit.author.login
 
 header = '@%s Jenkins CI reporting about code analysis' % author
 first_line = 'See the full report here: %s/violations' % build_url
-footer = 'You can run that yourself using buildout.coredev ``experimental/qa.cfg`` config file.'
+footer = 'Follow [these instructions](https://github.com/plone/jenkins.plone.org/blob/master/docs/source/run-qa-on-package.rst) to reproduce it locally.'
 comment = '%s\n%s\n```\n%s```\n%s' % (
     header,
     first_line,


### PR DESCRIPTION
To make the QA report on github more useful,
point users to the documentation that explains how to run code analysis locally.

This way the user has all the information needed to fix the code by herself.