### PR TITLE
Remove one step

### DIFF
--- a/scripts/pr-get-info.py
+++ b/scripts/pr-get-info.py
@@ -135,7 +135,9 @@ for pr in pull_request_urls.split():
     )
 
     if plone_repo != 'buildout.coredev':
+        # export the pacakges so it can be reported by mail
         PKGS.append(plone_repo)
+        # change the package source
         for line in fileinput.input('sources.cfg', inplace=True):
             if line.find(plone_repo) != -1:
                 line = re.sub(
@@ -144,6 +146,10 @@ for pr in pull_request_urls.split():
                     line
                 )
             sys.stdout.write(line)
+
+        # add the package on the checkouts
+        with open('checkouts.cfg', 'a') as myfile:
+            myfile.write('    {0}'.format(plone_repo))
     else:
         COREDEV = 1
 

--- a/scripts/pr-tests.sh
+++ b/scripts/pr-tests.sh
@@ -7,11 +7,6 @@ fi
 if [ "$COREDEV" = "1" ]; then
     # TODO(gforcada): allow to test remote branches (i.e. branches not in github.com/plone/buildout.coredev)
     git checkout $BRANCH
-else
-    bin/buildout -c jenkins.cfg install add-package-to-auto-checkout
-    for pkg in $PKGS; do
-        bin/add-package-to-auto-checkout $pkg
-    done
 fi
 
 bin/buildout -c jenkins.cfg


### PR DESCRIPTION
There is no need to run buildout to add packages to the checkouts,
to later have to run buildout again.

Do that directly on the preparation stage, so one buildout run can be avoided.

@tisto would you mind double checking that this assumption is correct?