### PR TITLE
Avoid running two jobs at the same time

### DIFF
--- a/scripts/4.3-tests.sh
+++ b/scripts/4.3-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # run buildout and tests
 {pybinary} bootstrap.py -c jenkins.cfg
+./marker.sh set $$
 bin/buildout -c jenkins.cfg
+./marker.sh release
 bin/jenkins-alltests -1

--- a/scripts/5.x-at.sh
+++ b/scripts/5.x-at.sh
@@ -2,5 +2,7 @@
 # buildout and AT tests
 sed -i 's/    mr.developer/    mr.developer\ngit-clone-depth = 100/' core.cfg
 $PYTHON27 bootstrap.py --setuptools-version 21.0.0 -c jenkins.cfg
+./marker.sh set $$
 bin/buildout -c jenkins.cfg
+./marker.sh release
 bin/alltests-at --xml

--- a/scripts/5.x-robot.sh
+++ b/scripts/5.x-robot.sh
@@ -2,6 +2,8 @@
 # buildout and robot tests
 sed -i 's/    mr.developer/    mr.developer\ngit-clone-depth = 100/' core.cfg
 $PYTHON27 bootstrap.py --setuptools-version 21.0.0 -c jenkins.cfg
+./marker.sh set $$
 bin/buildout -c jenkins.cfg
+./marker.sh release
 ROBOTSUITE_PREFIX=ONLYROBOT
 bin/alltests -t ONLYROBOT --all --xml

--- a/scripts/5.x-tests.sh
+++ b/scripts/5.x-tests.sh
@@ -2,5 +2,7 @@
 # buildout and core tests (no AT nor robot)
 sed -i 's/    mr.developer/    mr.developer\ngit-clone-depth = 100/' core.cfg
 $PYTHON27 bootstrap.py --setuptools-version 21.0.0 -c jenkins.cfg
+./marker.sh set $$
 bin/buildout -c jenkins.cfg
+./marker.sh release
 bin/alltests --xml

--- a/scripts/marker.sh
+++ b/scripts/marker.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+MARKER_FILE=~/BUILDOUT-RUNNING
+USAGE="
+Goal: claim a marker file, run buildout, then unclaim the file.
+This avoids issues building new packages when starting two Jenkins
+jobs on the same node.  See
+https://github.com/plone/jenkins.plone.org/issues/135
+
+Marker file with process id: $MARKER_FILE
+
+Usage:
+$0 set <pid of calling script>
+    Wait until marker file is no longer there
+    or until the process with the id is no longer running,
+    in case it got uncleanly broken off.
+$0 release
+    Cleanly release the marker file.
+"
+
+# 1. Wait for and set the marker.
+if test $# -eq 2 && test "$1" == "set"; then
+    # The second argument is the pid of the calling script.  In case
+    # it is bogus, the marker will be stolen by the next calling
+    # script, which is fine.
+    PID="$2"
+    while test -e $MARKER_FILE; do
+        OTHER_PID=$(cat $MARKER_FILE)
+        echo "Marker file $MARKER_FILE exists for PID $OTHER_PID."
+        if ! test $(pgrep -F $MARKER_FILE); then
+            echo "PID $OTHER_PID is no longer running. We will take over."
+            rm $MARKER_FILE
+        else
+            echo "Waiting..."
+            sleep 5
+        fi
+    done
+    echo $PID > $MARKER_FILE
+    echo "Created marker file $MARKER_FILE with our PID $PID."
+    exit 0
+fi
+
+# 2. Remove the marker.
+if test $# -eq 1 && test "$1" == "release"; then
+    if test -e $MARKER_FILE; then
+        rm -f $MARKER_FILE
+        echo "Removed marker file $MARKER_FILE."
+    else
+        echo "Marker file $MARKER_FILE was already removed."
+    fi
+    exit 0
+fi
+
+# If you end up here, you have not called the script correctly.
+echo "$USAGE"
+exit 1

--- a/scripts/pkg-qa.sh
+++ b/scripts/pkg-qa.sh
@@ -4,5 +4,7 @@ wget https://raw.githubusercontent.com/plone/buildout.coredev/5.1/experimental/q
 wget https://raw.githubusercontent.com/plone/plone.recipe.codeanalysis/master/.isort.cfg -O .isort.cfg
 sed -i 's#directory = src#directory = {top-level}#' qa.cfg
 $PYTHON27 bootstrap.py --setuptools-version 21.0.0 -c qa.cfg
+./marker.sh set $$
 bin/buildout -c qa.cfg
+./marker.sh release
 bin/code-analysis

--- a/scripts/plips.sh
+++ b/scripts/plips.sh
@@ -2,7 +2,9 @@
 # buildout, core and AT tests
 sed -i 's/    mr.developer/    mr.developer\ngit-clone-depth = 100/' core.cfg
 $PYTHON27 bootstrap.py --setuptools-version 21.0.0 -c {buildout}
+./marker.sh set $$
 bin/buildout -c {buildout}
+./marker.sh release
 
 return_code="all_right"
 

--- a/scripts/pr-tests.sh
+++ b/scripts/pr-tests.sh
@@ -14,7 +14,9 @@ else
     done
 fi
 
+./marker.sh set $$
 bin/buildout -c jenkins.cfg
+./marker.sh release
 
 return_code="all_right"
 

--- a/scripts/qa-global-code-analysis.sh
+++ b/scripts/qa-global-code-analysis.sh
@@ -2,7 +2,9 @@
 # checkout all packages
 sed -i 's/    mr.developer/    mr.developer\ngit-clone-depth = 100/' jenkins-package-dependencies.cfg
 $PYTHON27 bootstrap.py -c jenkins-package-dependencies.cfg
+./marker.sh set $$
 bin/buildout -c jenkins-package-dependencies.cfg
+./marker.sh release
 
 echo "" > qa.txt
 
@@ -11,7 +13,9 @@ sed -i 's#\[buildout\]#\[buildout\]\nbin-directory = ../bin#' experimental/qa.cf
 sed -i 's#\[buildout\]#\[buildout\]\nparts-directory = ../parts#' experimental/qa.cfg
 wget https://raw.githubusercontent.com/plone/plone.recipe.codeanalysis/master/.isort.cfg -O .isort.cfg
 
+./marker.sh set $$
 bin/buildout -c experimental/qa.cfg
+./marker.sh release
 
 blacklist="Plone plone.themepreview diazo jquery.recurrenceinput.js mockup mockup-core"
 for pkg in src/*;


### PR DESCRIPTION
This tackles issue #135.
I encountered this problem again today. I released a package and updated a coredev buildout for this, multiple jobs were started, some on the same server, and this goes wrong: a package gets installed by job 1, but halfway through this process job 2 does the same, and the result is a broken package.

For example, node 3 now has a broken Products.CMFDiffTool, which results in `ImportError: No module named CMFDiffTool.interfaces`: http://jenkins.plone.org/job/plone-5.1-python-2.7-at/218/console

I have restarted that job, but the new one is on node 3 too, so it will fail. Sigh, the second and third tries start on node 3 too, so I started a fourth one, which finally starts on node 4... Can someone have a look, removing the CMFDiffTool egg from node 3? Alternatively, I can make another release. [Edit: the three jobs indeed failed and the fourth job passed. But the next Plone 5.0/5.1 job that starts on node three will fail again.]

Anyway, I propose to solve this. https://github.com/plone/jenkins.plone.org/issues/135 has some ideas. I went for the hardest one, but at least that one does not negatively impact the hard disk space. But maybe that is not such a big problem after all, so other solutions are fine with me. The underlying problem has cost me too much time and effort already.

In this pull request I have added a script `marker.sh`. The Jenkins test scripts call that script before the buildout run to set a marker file. After the buildout run, they call the script again to remove it. If the marker file already exists, the Jenkins script waits. It is smart enough to retry a couple of times, and check if the process id that is stored in the marker file is still running, or if it changes.

You can test it locally by creating a script like this:

```
#!/bin/bash
# Claim marker with our pid
# $$ is the PID of this script.
./marker.sh set $$
# Act busy.
echo "Pretending to run buildout..."
for i in $(seq 12); do
    sleep 1
    echo $i
done
./marker.sh release
```

Then run this test script in two terminals at the same time and see what happens. Let them run normally, or kill one, and maybe quickly restart the script, or edit the marker file to have the process id of a different process that is long running. Get a feel for how it works.

I think it does a good job. But note that the goal is not to have an optimized, completely watertight solution, but to have a solution that does not deadlock. Waiting a minute before the buildout starts is fine. Waiting an hour, or even forever, needing an admin to login and fix things, is not.

I suggest to test this locally and then copy the `marker.sh` and the above test script to a Jenkins server to test it manually. For example, I wonder if the `pgrep` command is available.