### PR TITLE
Add-on job

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ Contents
    vagrant
    run-pull-request-jobs
    run-qa-on-package
+   run-add-on-jobs
 
 .. include:: ../../README.rst
 

--- a/docs/source/run-add-on-jobs.rst
+++ b/docs/source/run-add-on-jobs.rst
@@ -1,0 +1,47 @@
+.. -*- coding: utf-8 -*-
+
+===============
+Run add-on jobs
+===============
+Before a final release of Plone core is done,
+add-ons might want to check if they need any porting effort to make the add-on compatible with it.
+
+For that we have some special jenkins jobs:
+
+- If the add-on targets Plone 5.1: http://jenkins.plone.org/job/test-addon-5.1
+- If the add-on targets Plone 5.0: http://jenkins.plone.org/job/test-addon-5.0
+- If the add-on targets Plone 4.3: http://jenkins.plone.org/job/test-addon-4.3
+
+Test an add-on
+==============
+- go to http://jenkins.plone.org
+- log in with your github user
+- click on the `Test add-on against Plone 5.1 job <http://jenkins.plone.org/job/test-addon-5.1>`_
+  or `Test add-on against Plone 5.0 job <http://jenkins.plone.org/job/test-addon-5.0>`_
+  or `Test add-on against Plone 4.3 job <http://jenkins.plone.org/job/test-addon-4.3>`_ if you are targeting that Plone version
+- click on the huge button **Build with Parameters**
+  `Plone 5.1 <http://jenkins.plone.org/job/test-addon-5.1/build?delay=0sec>`_ or
+  `Plone 5.0 <http://jenkins.plone.org/job/test-addon-5.0/build?delay=0sec>`_ or
+  `Plone 4.3 <http://jenkins.plone.org/job/test-addon-4.3/build?delay=0sec>`_
+- paste the add-on git URL for the add-on that you want to test on the ``ADDON_URL`` field,
+  for example https://github.com/collective/collective.cover.git
+- *(optionally)* type the branch you want to test the add-on against on the ``ADDON_BRANCH`` field,
+  by default it will be the master branch
+- click on the ``Build`` button
+
+.. note::
+   For the jobs to work properly they need to get the add-on name out of the URL,
+   for that, the last path of the URL will be used,
+   i.e. https://github.com/my-org/my-cool-repo.git or https://gitlab.com/another-org/project/something/else/my-cool-repo.git
+   If not the add-on name can not be guessed with a regular expression.
+
+GitHub integration
+==================
+A comment will be added on the latest commit on that branch once the job finishes.
+
+Mail integration
+================
+When the jenkins job is finished it will report by mail to the user that started the jenkins job.
+
+On the mail,
+the status of the job will be provided.

--- a/jobs.yml
+++ b/jobs.yml
@@ -82,6 +82,15 @@
         - 'pull-request-{plone-version}'
 
 - project:
+    name: Test add-ons
+    plone-version:
+        - '5.1'
+        - '5.0'
+        - '4.3'
+    jobs:
+        - 'test-addon-{plone-version}'
+
+- project:
     name: Plone 5.x
     plone-version:
         - '5.1'
@@ -699,6 +708,53 @@
 
     <<: *plone-xvfb
 
+- job-template:
+    name: 'test-addon-{plone-version}'
+    display-name: 'Test add-on against Plone {plone-version}'
+    description: |
+        Run an add-on tests with the current checkouts of Plone {plone-version}.
+        To trigger a job, login with your GitHub account and provide the anonymous git URL of you add-on and, optionally, a branch.
+        After the job is finished you will get an email about the result.
+
+    parameters:
+        - text:
+            name: ADDON_URL
+            description: 'URL of the add-on git repository, something like https://github.com/collective/collective.cover.git, see the documentation http://jenkinsploneorg.readthedocs.io/en/latest/run-add-on-jobs.html'
+
+        - text:
+            name: ADDON_BRANCH
+            description: 'branch of the add-on that should be tested, if left blank, master branch is assumed'
+
+    scm:
+        - buildout-coredev:
+            branch: '{plone-version}'
+
+    builders:
+        - python:
+            !include-raw-escape: scripts/addon-get-info.py
+
+        - inject:
+            properties-file: vars.properties
+
+        - shell:
+            !include-raw: scripts/addon-tests.sh
+
+    publishers:
+        - junit:
+            results: 'parts/test/testreports/*.xml'
+            keep-long-stdio: false
+
+        - email-ext:
+            recipients: "${{BUILD_USER_EMAIL}}"
+            reply-to:
+            content-type: default
+            always: true
+            failure: false
+            subject: "[${{BUILD_STATUS}}]: ${{ADDON_NAME}} tested against {plone-version}"
+            body:
+                !include-raw: scripts/addon.email
+
+    <<: *plone-basic
 
 - job-template:
     name: plone-package-dependencies-{kind}

--- a/scripts/addon-get-info.py
+++ b/scripts/addon-get-info.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+from github import Github
+from github.GithubException import BadCredentialsException
+from github.GithubException import UnknownObjectException
+
+import fileinput
+import os
+import re
+import sys
+
+
+class AddonInfo(object):
+
+    addon_name = ''
+    addon_url = ''
+    addon_branch = 'master'
+    in_known_github_org = False
+    github_org = ''
+
+    github_api_key = ''
+    github = None
+    latest_commit = ''
+
+    known_github_orgs = (
+        ('github.com/collective', 'collective', ),
+        ('github.com/plone', 'plone', ),
+    )
+
+    def process_input(self):
+        self.get_addon_details()
+        if self.in_known_github_org:
+            self.get_gitub_api_key()
+            self.github = Github(self.github_api_key)
+            self.latest_commit = self.get_latest_commit()
+
+    def get_addon_details(self):
+        try:
+            self.addon_url = os.environ['ADDON_URL']
+        except KeyError:
+            print(
+                '\n\n\n'
+                'You seem to forgot to add an add-on URL on the '
+                '"Build with parameters" form!'
+                '\n\n\n'
+            )
+            sys.exit(1)
+
+        try:
+            self.addon_branch = os.environ['ADDON_BRANCH']
+        except KeyError:
+            self.addon_branch = None
+
+        if self.addon_branch is None:
+            self.addon_branch = 'master'
+
+        for org_data in self.known_github_orgs:
+            if org_data[0] in self.addon_url:
+                self.in_known_github_org = True
+                self.github_org = org_data[1]
+                break
+
+        self.addon_name = self._get_addon_name()
+
+    def _get_addon_name(self):
+        url = self.addon_url
+        if self.addon_url.endswith('.git'):
+            url = self.addon_url[:-4]  # Remove the `.git` suffix
+        matches = re.search(r'/([\d\w.\-_]+?)$', url)
+        if matches:
+            return matches.groups()[0]
+        else:
+            print(
+                '\n\n\n'
+                'Could not get the add-on name out of the URL, '
+                'be sure that the last part of the URL is the add-on name.'
+                '\n\n\n'
+            )
+            sys.exit(1)
+
+    def get_gitub_api_key(self):
+        try:
+            self.github_api_key = os.environ['GITHUB_API_KEY']
+        except KeyError:
+            print(
+                '\n\n\n'
+                'GITHUB_API_KEY is missing, this job can not run without it. '
+                '\n'
+                'Please contact the testing team: '
+                'https://github.com/orgs/plone/teams/testing-team'
+                '\n'
+                'Fill an issue as well: '
+                'https://github.com/plone/jenkins.plone.org/issues/new'
+                '\n\n\n'
+            )
+            sys.exit(1)
+
+    def get_latest_commit(self):
+        try:
+            g_organization = self.github.get_organization(self.github_org)
+            g_repository = g_organization.get_repo(self.addon_name)
+            g_branch = g_repository.get_branch(self.addon_branch)
+            return g_branch.commit.sha
+        except BadCredentialsException:
+            print(
+                '\n\n\n'
+                'The API key used seems to not be valid any longer.'
+                '\n'
+                'Please contact the testing team: '
+                'https://github.com/orgs/plone/teams/testing-team'
+                '\n'
+                'Fill an issue as well: '
+                'https://github.com/plone/jenkins.plone.org/issues/new'
+                '\n\n\n'
+            )
+            sys.exit(1)
+        except UnknownObjectException:
+            msg = (
+                '\n\n\n'
+                'Error on trying to get info from add-on URL %s'
+                '\n'
+                'Double check that the provided information is valid.'
+                '\n\n\n'
+            )
+            print(msg % (self.addon_url, self.github_org))
+            sys.exit(1)
+
+    def write_properties_file(self):
+        print('add-on name: ' + self.addon_name)
+        print('add-on URL: ' + self.addon_url)
+        print('add-on branch: ' + self.addon_branch)
+        print('add-on in github: ' + str(self.in_known_github_org))
+        print('add-on github org: ' + self.github_org)
+        print('add-on latest commit: ' + self.latest_commit)
+        msg = (
+            'ADDON_NAME = {0}\n'
+            'ADDON_URL = {1}\n'
+            'ADDON_BRANCH = {2}\n'
+            'REPORT_ON_GITHUB = {3}\n'
+            'GITHUB_LATEST_COMMIT = {4}\n'
+        )
+        data = [
+            self.addon_name,
+            self.addon_url,
+            self.addon_branch,
+            str(self.in_known_github_org),
+            self.latest_commit,
+        ]
+
+        with open('vars.properties', 'w') as f:
+            f.write(msg.format(*data))
+
+    def add_package_to_buildout(self):
+        # add the package on the checkouts
+        with open('checkouts.cfg', 'a') as myfile:
+            myfile.write('    {0}'.format(self.addon_name))
+
+        # add the package on sources
+        with open('sources.cfg', 'a') as myfile:
+            myfile.write('{0} = git {1} rev={2}'.format(
+                self.addon_name,
+                self.addon_url,
+                self.latest_commit,
+            ))
+
+        # add the package to tests.cfg
+        for line in fileinput.input('tests.cfg', inplace=True):
+            if line.find('Products.CMFPlone [test]') != -1:
+                # TODO(gforcada): what if the add-on needs some extras??
+                line = '    Products.CMFPlone [test]\n    {0}\n'
+                line = line.format(self.addon_name)
+            sys.stdout.write(line)
+
+
+add_on = AddonInfo()
+add_on.process_input()
+add_on.add_package_to_buildout()
+add_on.write_properties_file()
+"""
+RUN TEST
+- report with a comment if REPORT_ON_GITHUB is true
+  - if tests pass and no trove classifier is found, warn about it
+
+REPORT BY EMAIL
+  - if tests pass and no trove classifier is found, warn about it
+"""

--- a/scripts/addon-tests.sh
+++ b/scripts/addon-tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+if [ "{plone-version}" = "4.3" ]; then
+    $PYTHON27 bootstrap.py -c jenkins.cfg
+else
+    $PYTHON27 bootstrap.py --setuptools-version 26.1.1 --buildout-version 2.8.0 -c jenkins.cfg
+fi
+
+bin/buildout -c jenkins.cfg
+bin/test --xml -s ${{ADDON_NAME}}
+
+#if [ "${{REPORT_ON_GITHUB}}" = "True" ]; then
+#    $PYTHON27 templates/addon-report_status.py
+#fi

--- a/scripts/addon.email
+++ b/scripts/addon.email
@@ -1,0 +1,13 @@
+Dear ${{BUILD_USER}},
+
+the Jenkins add-on test for ${{ADDON_NAME}} has finished:
+
+${{BUILD_URL}}
+
+As tests go green, please ensure you add the proper trove classifier to your setup.py:
+
+Framework :: Plone :: {plone-version}
+
+
+Yours truly,
+Jenkins


### PR DESCRIPTION
This set of jobs create 3 new jenkins jobs that, just like the pull request jobs allows you to test a pull request against a development version of Plone, these jobs allow an add-on tests to be run on that very same environment as well.

TODO/missing:
- what to do if add-ons have a ``[test]`` extra?
- ~~integration with github (leave a comment at the tip of the branch being tested with the result)~~ DONE
- robot framework tests do not run, as jenkins complains if there are no results (could we just fake them if there is nothing(?)

The although this is still to be merged the jenkins jobs are already up on jenkins.plone.org:
- http://jenkins.plone.org/job/test-addon-4.3
- http://jenkins.plone.org/job/test-addon-5.0
- http://jenkins.plone.org/job/test-addon-5.1

Please give them a try and report any feedback.