### PR TITLE
Added missing newline for PKGS if COREDEV=1.

### DIFF
--- a/scripts/pr-get-info.py
+++ b/scripts/pr-get-info.py
@@ -165,5 +165,5 @@ with open('vars.properties', 'w') as f:
     f.write(u'PKGS = {0}\n'.format(' '.join(PKGS)))
     f.write(u'COREDEV = {0}\n'.format(COREDEV))
     if COREDEV == 1:
-        f.write(u'PKGS = ')
+        f.write(u'PKGS = \n')
         f.write(u'BRANCH = {0}\n'.format(branch))


### PR DESCRIPTION
See https://github.com/plone/buildout.coredev/pull/333#issuecomment-298892929

The code on master results in:

```
PKGS = BRANCH = some-branch
```

With the fix, it becomes:

```
PKGS = 
BRANCH = some-branch
```

Without this, a pull request for a coredev branch, will fail to check it out.