### PR TITLE
WIP: robotshots job

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -261,6 +261,7 @@
     jobs:
         - qa-docs-package-styleguide
         - qa-docs-age
+        - qa-docs-screenshots
         - qa-undeclared-dependencies
         - qa-code-analysis
         - qa-i18n-find-untranslated
@@ -1094,6 +1095,47 @@
         - custom-workspace-cleanup
 
     <<: *plone-basic
+
+- job:
+    name: qa-docs-screenshots
+    display-name: 'Screenshots for docs'
+
+    scm:
+        - buildout-coredev:
+            branch: '5.2'
+
+    triggers:
+        - timed: '@weekly'
+
+    builders:
+        - shining-panda:
+            build-environment: virtualenv
+            python-version: System-CPython-2.7
+            clear: true
+            nature: shell
+            command:
+                !include-raw: scripts/robotshots.sh
+
+    publishers:
+
+        - robot:
+            output-path: parts/test
+            report-html: robot_report.html
+            log-html: robot_log.html
+            output-xml: robot_output.xml
+            pass-threshold: 100.0
+            unstable-threshold: 80.0
+            only-critical: true
+            other-files:
+                - robot_*.png
+
+    wrappers:
+        - custom-workspace-cleanup
+        - custom-timeout
+        - custom-port-allocator
+        - custom-xvfb
+
+    <<: *plone-xvfb
 
 
 - job:

--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -1102,7 +1102,7 @@
 
     scm:
         - buildout-coredev:
-            branch: '5.2'
+            branch: '5.1'
 
     triggers:
         - timed: '@weekly'

--- a/jobs/scripts/robotshots.sh
+++ b/jobs/scripts/robotshots.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+sed -i 's/    mr.developer/    mr.developer\ngit-clone-depth = 100/' core.cfg
+pip install -r requirements.txt
+buildout -c jenkins.cfg
+bin/pybot -v BROWSER:phantomjs src/Products.CMFPlone/Products/CMFPlone/tests/robot/robodoc

--- a/jobs/scripts/robotshots.sh
+++ b/jobs/scripts/robotshots.sh
@@ -2,4 +2,5 @@
 sed -i 's/    mr.developer/    mr.developer\ngit-clone-depth = 100/' core.cfg
 pip install -r requirements.txt
 buildout -c jenkins.cfg
-bin/pybot -v BROWSER:phantomjs src/Products.CMFPlone/Products/CMFPlone/tests/robot/robodoc
+#bin/pybot -v BROWSER:phantomjs src/Products.CMFPlone/Products/CMFPlone/tests/robot/robodoc
+bin/pybot src/Products.CMFPlone/Products/CMFPlone/tests/robot/robodoc


### PR DESCRIPTION
The job is already there: http://jenkins.plone.org/view/QA/job/qa-docs-screenshots

Although it seems to be failing, maybe we don't have phantomjs on jenkins?

See for details: https://github.com/plone/papyrus/issues/127

@polyester which plone version should we target? 5.1 to get a recent *but* stable version or 5.2 which seems to be more of a headless chicken right now?

Steps:
- [x] get a job
- [x] get the job to pass
- [ ] push screenshots to repo https://github.com/plone/documentation-roboshots

Extras:
- [ ] multiversion? Which ones? 5.0, 5.1 and *"master"*
- [ ] others?