### PR TITLE
Fix PLIP buildout initialization

### DIFF
--- a/jobs/scripts/plips.sh
+++ b/jobs/scripts/plips.sh
@@ -5,7 +5,7 @@ if [ "{py}" = "2.7" ]; then
     sed 's#buildout-py3.cfg#buildout-py2.cfg#' plips/plipbase.cfg
 fi
 
-buildout buildout:git-clone-depth=1 -c ${buildout}
+buildout buildout:git-clone-depth=1 -c {buildout}
 
 export PATH="/usr/lib/chromium-browser:$PATH"
 export ROBOT_BROWSER=chrome


### PR DESCRIPTION
Looking at the changelog https://github.com/plone/jenkins.plone.org/commit/bac9d0e47f5d2dd293ab66819e3b722a565d90a8 it looks like the ``$`` in ``${buildout}`` needs to be removed.

@gforcada does this fix the problem described in: https://github.com/plone/buildout.coredev/issues/549 ?