### PR TITLE
Adapt jobs to buildout.coredev PR #555

### DIFF
--- a/jobs/scripts/5.x-robot.sh
+++ b/jobs/scripts/5.x-robot.sh
@@ -5,12 +5,8 @@ BUILDOUT="core.cfg"
 SCRIPT="bin/alltests"
 
 if [ "{plone-version}" = "5.2" ]; then
-    BUILDOUT="buildout-py3.cfg"
+    BUILDOUT="buildout.cfg"
     SCRIPT="bin/test"
-
-    if [ "{py}" = "2.7" ]; then
-        BUILDOUT="buildout-py2.cfg"
-    fi
 fi
 
 buildout buildout:git-clone-depth=1 -c ${{BUILDOUT}}

--- a/jobs/scripts/5.x-tests.sh
+++ b/jobs/scripts/5.x-tests.sh
@@ -5,12 +5,8 @@ BUILDOUT="core.cfg"
 SCRIPT="bin/alltests"
 
 if [ "{plone-version}" = "5.2" ]; then
-    BUILDOUT="buildout-py3.cfg"
+    BUILDOUT="buildout.cfg"
     SCRIPT="bin/test"
-
-    if [ "{py}" = "2.7" ]; then
-        BUILDOUT="buildout-py2.cfg"
-    fi
 fi
 
 buildout buildout:git-clone-depth=1 -c ${{BUILDOUT}}

--- a/jobs/scripts/plips.sh
+++ b/jobs/scripts/plips.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 pip install -r requirements.txt
 
-if [ "{py}" = "2.7" ]; then
-    sed 's#buildout-py3.cfg#buildout-py2.cfg#' plips/plipbase.cfg
-fi
-
 buildout buildout:git-clone-depth=1 -c {buildout}
 
 export PATH="/usr/lib/chromium-browser:$PATH"

--- a/jobs/scripts/pr-tests-py2.sh
+++ b/jobs/scripts/pr-tests-py2.sh
@@ -10,7 +10,7 @@ pip install -r requirements.txt
 if [ "{plone-version}" = "4.3" ]; then
     buildout buildout:git-clone-depth=1 -c jenkins.cfg
 elif [ "{plone-version}" = "5.2" ]; then
-    buildout buildout:git-clone-depth=1 -c buildout-py2.cfg
+    buildout buildout:git-clone-depth=1 -c buildout.cfg
 else
     buildout buildout:git-clone-depth=1 -c core.cfg
 fi

--- a/jobs/scripts/pr-tests.sh
+++ b/jobs/scripts/pr-tests.sh
@@ -6,9 +6,10 @@ if [ "$COREDEV" = "1" ]; then
 fi
 
 pip install -r requirements.txt
-buildout buildout:git-clone-depth=1 -c buildout-py3.cfg
+buildout buildout:git-clone-depth=1 -c buildout.cfg
 
 return_code="all_right"
+
 export PATH="/usr/lib/chromium-browser:$PATH"
 export ROBOT_BROWSER='chrome'
 


### PR DESCRIPTION
There are no more buildout-py3.cfg and buildout-py2.cfg one to rule them
all is enough (thanks to a zc.buildout feature).