### PR TITLE
Use headless browsers and drop use of Xvfb

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -130,8 +130,8 @@
         - '3.7':
             python-version: 'Python3.7'
     browser:
-        - firefox
-        - chrome
+        - headlessfirefox
+        - headlesschrome
     jobs:
         - 'plone-{plone-version}-python-{py}-robot-{browser}'
 
@@ -154,8 +154,8 @@
         - '2.7':
             python-version: 'Python2.7'
     browser:
-        - firefox
-        - chrome
+        - headlessfirefox
+        - headlesschrome
     jobs:
         - 'plone-{plone-version}-python-{py}-robot-{browser}'
 
@@ -632,12 +632,6 @@
         - port-allocator:
             names:
                 - ZSERVER_PORT
-        - xvfb:
-            name: default
-            screen: 1200x900x24
-            debug: false
-            timeout: 0
-            shutdown: false
 
         - inject:
             properties-content: |

--- a/jobs/scripts/4.3-tests.sh
+++ b/jobs/scripts/4.3-tests.sh
@@ -4,6 +4,6 @@
 bin/buildout buildout:git-clone-depth=1 -c jenkins.cfg
 
 export PATH="/usr/lib/chromium-browser:$PATH"
-export ROBOT_BROWSER=chrome
+export ROBOT_BROWSER=headlesschrome
 
-xvfb-run -a --server-args='-screen 0 1920x1200x24' bin/jenkins-alltests -1
+bin/jenkins-alltests -1

--- a/jobs/scripts/5.x-robot.sh
+++ b/jobs/scripts/5.x-robot.sh
@@ -15,4 +15,4 @@ export PATH="/usr/lib/chromium-browser:$PATH"
 export ROBOT_BROWSER={browser}
 export ROBOTSUITE_PREFIX=ONLYROBOT
 
-xvfb-run -a --server-args='-screen 0 1920x1200x24' ${{SCRIPT}} -t ONLYROBOT --all --xml
+${{SCRIPT}} -t ONLYROBOT --all --xml

--- a/jobs/scripts/plips.sh
+++ b/jobs/scripts/plips.sh
@@ -4,6 +4,6 @@ pip install -r requirements.txt
 buildout buildout:git-clone-depth=1 -c {buildout}
 
 export PATH="/usr/lib/chromium-browser:$PATH"
-export ROBOT_BROWSER=chrome
+export ROBOT_BROWSER=headlesschrome
 
-xvfb-run -a --server-args='-screen 0 1920x1200x24' bin/test --xml --all
+bin/test --xml --all

--- a/jobs/scripts/pr-tests-py2.sh
+++ b/jobs/scripts/pr-tests-py2.sh
@@ -18,15 +18,15 @@ fi
 return_code="all_right"
 
 export PATH="/usr/lib/chromium-browser:$PATH"
-export ROBOT_BROWSER='chrome'
+export ROBOT_BROWSER='headlesschrome'
 
 if [ "{plone-version}" = "4.3" ]; then
-    xvfb-run -a --server-args='-screen 0 1920x1200x24' bin/jenkins-alltests -1 || return_code=$?
+    bin/jenkins-alltests -1 || return_code=$?
 elif [ "{plone-version}" = "5.2" ]; then
-    xvfb-run -a --server-args='-screen 0 1920x1200x24' bin/test --all --xml || return_code=$?
+    bin/test --all --xml || return_code=$?
 else
-    xvfb-run -a --server-args='-screen 0 1920x1200x24' bin/alltests --xml --all || return_code=$?
-    xvfb-run -a --server-args='-screen 0 1920x1200x24' bin/alltests-at --xml || return_code=$?
+    bin/alltests --xml --all || return_code=$?
+    bin/alltests-at --xml || return_code=$?
 fi
 
 if [ $return_code = "all_right" ]; then

--- a/jobs/scripts/pr-tests.sh
+++ b/jobs/scripts/pr-tests.sh
@@ -11,9 +11,9 @@ buildout buildout:git-clone-depth=1 -c buildout.cfg
 return_code="all_right"
 
 export PATH="/usr/lib/chromium-browser:$PATH"
-export ROBOT_BROWSER='chrome'
+export ROBOT_BROWSER='headlesschrome'
 
-xvfb-run -a --server-args='-screen 0 1920x1200x24' bin/test --all --xml  || return_code=$?
+bin/test --all --xml  || return_code=$?
 
 if [ $return_code = "all_right" ]; then
     return_code=$?


### PR DESCRIPTION
The versions of Robot and the Selenium drivers we use already support using headless browsers out of the box. This enables us to set the window size for the browsers more liberally and have less window management quirks get in our way thus eliminating many categories of flaky failures in Robot tests.

This is a part of the drive starting from:
https://github.com/plone/plone.app.robotframework/pull/110

The aim is for developers to also use headless browsers locally so we could have consistent results across the whole ecosystem.