### PR TITLE
Fixed file name for image srcsets plip.

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -243,7 +243,7 @@
     name: PLIPs
     plip:
         - plip-image-srcsets:
-             buildout: plips/plip-img-srcsets.cfg
+             buildout: plips/plip-image-srcsets.cfg
              branch: '6.0'
     py:
         - '3.9':


### PR DESCRIPTION
I have already fixed this manually on Jenkins.