### PR TITLE
Add PLIP job for image scales metadata.

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -242,8 +242,8 @@
 - project:
     name: PLIPs
     plip:
-        - plip-image-srcsets:
-             buildout: plips/plip-image-srcsets.cfg
+        - plip-image-scales-metadata:
+             buildout: plips/plip-image-scales-metadata.cfg
              branch: '6.0'
     py:
         - '3.9':


### PR DESCRIPTION
Let this replace the merged image srcsets PLIP.
See https://github.com/plone/Products.CMFPlone/pull/3521

I almost wanted to login on Jenkins and manually edit the configuration of the old PLIP jobs, but that does not seem very nice. Better do the official route.