### PR TITLE
Removed Python 3.7 from Plone 6.0 jobs.

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -93,8 +93,6 @@
             python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
-        - '3.7':
-            python-version: 'Python3.7'
     jobs:
         - 'pull-request-{plone-version}-{py}'
 
@@ -106,19 +104,30 @@
         - 'test-addon-{plone-version}'
 
 - project:
-    name: Test add-ons on python 3
+    name: Test add-ons on Plone 5.2 Python 3
     plone-version:
-        - '6.0'
         - '5.2'
     py:
-        - '3.9':
-            python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
         - '3.7':
             python-version: 'Python3.7'
         - '3.6':
             python-version: 'Python3.6'
+    jobs:
+        - 'test-addon-{plone-version}-{py}'
+
+- project:
+    name: Test add-ons on Plone 6.0 Python 3
+    plone-version:
+        - '6.0'
+    py:
+        - '3.10':
+            python-version: 'Python3.10'
+        - '3.9':
+            python-version: 'Python3.9'
+        - '3.8':
+            python-version: 'Python3.8'
     jobs:
         - 'test-addon-{plone-version}-{py}'
 
@@ -152,8 +161,6 @@
             python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
-        - '3.7':
-            python-version: 'Python3.7'
     jobs:
         - 'plone-{plone-version}-python-{py}'
 
@@ -189,8 +196,6 @@
             python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
-        - '3.7':
-            python-version: 'Python3.7'
     browser:
         - chrome
     jobs:


### PR DESCRIPTION
Fixes issue #308.

I already removed them manually in the Jenkins UI, but we don't want them coming back.

I also split the 'Test add-ons on python 3' project in one project for 5.2 and one for 6.0. Use the correct Python versions there. These add-on jobs are hardly used though, so we could also remove them. Or advertise them more, I think @gforcada added a comment in an add-on recently.