### PR TITLE
add volto translation jobs for master and 16.x.x

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -182,6 +182,7 @@
     branch:
         - '16.x.x'
         - 'master'
+    python-version: 'Python3.9'
     jobs:
         - 'volto-translations-{branch}'
 

--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -178,9 +178,12 @@
         - 'plone-{plone-version}-python-{py}-i18n-find-missing'
 
 - project:
-    name: Translations of Volto
+    name: Translations of Volto (16.x.x)
+    branch:
+        - '16.x.x'
+        - 'master'
     jobs:
-        - 'volto-translations'
+        - 'volto-translations-{branch}'
 
 - project:
     name: PLIPs
@@ -240,14 +243,14 @@
     <<: *plone-basic
 
 - job-template:
-    name: volto-translations
-    display-name: 'Volto translations'
+    name: volto-translations-{branch}
+    display-name: 'Volto translations - {branch}'
 
     scm:
         - git:
             url: https://github.com/plone/volto.git
             branches:
-                - master
+                - '{branch}'
             wipe-workspace: false
             tag-builds: true
             shallow-clone: true


### PR DESCRIPTION
Now that we have Volto 16.x.x LTS in its own branch, it is worth to have the translation status for it and `master` also.

Can you review if the syntax is OK and if so deploy it?