### PR TITLE
Add PR job for Plone 6.1 on Python 3.11

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -70,7 +70,7 @@
         - 'pull-request-{plone-version}-{py}'
 
 - project:
-    name: Pull requests on Plone 6 for python 3
+    name: Pull requests on Plone 6.0
     plone-version:
         - '6.0'
     py:
@@ -82,6 +82,16 @@
             python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
+    jobs:
+        - 'pull-request-{plone-version}-{py}'
+
+- project:
+    name: Pull requests on Plone 6.1
+    plone-version:
+        - '6.0'
+    py:
+        - '3.11':
+            python-version: 'Python3.11'
     jobs:
         - 'pull-request-{plone-version}-{py}'
 


### PR DESCRIPTION
The other python versions and regular Plone 6.1 jobs will be added later.

Note that the job is already created, although manually: https://jenkins.plone.org/job/pull-request-6.1-3.11

See #332