### PR TITLE
feat: drop Plone 6.0 jobs for python 3.9 and 3.10

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -101,8 +101,6 @@
     py:
         - '3.8':
             python-version: 'Python3.8'
-        - '3.7':
-            python-version: 'Python3.7'
     jobs:
         - 'plone-{plone-version}-python-{py}'
 
@@ -113,10 +111,6 @@
     py:
         - '3.11':
             python-version: 'Python3.11'
-        - '3.10':
-            python-version: 'Python3.10'
-        - '3.9':
-            python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
     jobs:
@@ -144,8 +138,6 @@
     py:
         - '3.8':
             python-version: 'Python3.8'
-        - '3.7':
-            python-version: 'Python3.7'
     browser:
         - chrome
     jobs:
@@ -158,10 +150,6 @@
     py:
         - '3.11':
             python-version: 'Python3.11'
-        - '3.10':
-            python-version: 'Python3.10'
-        - '3.9':
-            python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
     browser:
@@ -180,6 +168,54 @@
         - chrome
     jobs:
         - 'plone-{plone-version}-python-{py}-robot-{browser}'
+
+- project:
+    name: Plone 5.2 jobs on python 3.x (scheduled)
+    plone-version:
+        - '5.2'
+    py:
+        - '3.7':
+            python-version: 'Python3.7'
+    jobs:
+        - 'plone-{plone-version}-python-{py}-scheduled'
+
+- project:
+    name: Plone 6.0 jobs on python 3.x (scheduled)
+    plone-version:
+        - '6.0'
+    py:
+        - '3.10':
+            python-version: 'Python3.10'
+        - '3.9':
+            python-version: 'Python3.9'
+    jobs:
+        - 'plone-{plone-version}-python-{py}-scheduled'
+
+- project:
+    name: Plone 5.2 jobs on python 3.x (robot tests) (scheduled)
+    plone-version:
+        - '5.2'
+    py:
+        - '3.7':
+            python-version: 'Python3.7'
+    browser:
+        - chrome
+    jobs:
+        - 'plone-{plone-version}-python-{py}-robot-{browser}-scheduled'
+
+- project:
+    name: Plone 6.0 jobs on python 3.x (robot tests) (scheduled)
+    plone-version:
+        - '6.0'
+    py:
+        - '3.10':
+            python-version: 'Python3.10'
+        - '3.9':
+            python-version: 'Python3.9'
+    browser:
+        - chrome
+    jobs:
+        - 'plone-{plone-version}-python-{py}-robot-{browser}-scheduled'
 
 - project:
     name: Translations on Plone 5.2 for python 2.7
@@ -335,8 +371,8 @@
     <<: *plone
 
 
-- job-template:
-    # Plone 5.x core tests job definition.
+- job-template: &plone-core
+    # Plone core tests job definition.
     name: plone-{plone-version}-python-{py}
     display-name: 'Plone {plone-version} - Python {py}'
 
@@ -354,6 +390,16 @@
 
     <<: *plone
 
+
+- job-template:
+    # Plone core tests job definition.
+    name: plone-{plone-version}-python-{py}-scheduled
+    display-name: 'Plone {plone-version} - Python {py} (scheduled)'
+
+    triggers:
+        - timed: "@weekly"
+
+    <<: *plone-core
 
 - job:
     # Plone 5.x robot tests job definition.
@@ -398,8 +444,8 @@
     <<: *plone
 
 
-- job-template:
-    # Plone 5.x robot tests job definition.
+- job-template: &plone-core-robot
+    # Plone robot tests job definition.
     name: plone-{plone-version}-python-{py}-robot-{browser}
     display-name: 'Plone {plone-version} - Python {py} - Robot Framework Tests ({browser})'
 
@@ -434,6 +480,17 @@
             properties-content: ROBOTSUITE_PREFIX=ONLYROBOT
 
     <<: *plone
+
+
+- job-template:
+    # Plone robot tests job definition.
+    name: plone-{plone-version}-python-{py}-robot-{browser}-scheduled
+    display-name: 'Plone {plone-version} - Python {py} - Robot Framework Tests ({browser}) (scheduled)'
+
+    triggers:
+        - timed: "@weekly"
+
+    <<: *plone-core-robot
 
 - job-template:
     # PLIPs jobs definition

--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -64,8 +64,6 @@
     py:
         - '3.8':
             python-version: 'Python3.8'
-        - '3.7':
-            python-version: 'Python3.7'
     jobs:
         - 'pull-request-{plone-version}-{py}'
 
@@ -76,10 +74,6 @@
     py:
         - '3.11':
             python-version: 'Python3.11'
-        - '3.10':
-            python-version: 'Python3.10'
-        - '3.9':
-            python-version: 'Python3.9'
         - '3.8':
             python-version: 'Python3.8'
     jobs:

--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -52,87 +52,17 @@
 # PROJECTS
 ###
 
+### CORE JOBS
+
 - project:
-    name: Pull requests on Plone 5.2 for python 2
+    name: Plone 5.2 on python 2
     jobs:
         - 'pull-request-5.2-2.7'
-
-- project:
-    name: Pull requests on Plone 5.2 for python 3
-    plone-version:
-        - '5.2'
-    py:
-        - '3.8':
-            python-version: 'Python3.8'
-    jobs:
-        - 'pull-request-{plone-version}-{py}'
-
-- project:
-    name: Pull requests on Plone 6.0 for python 3
-    plone-version:
-        - '6.0'
-    py:
-        - '3.11':
-            python-version: 'Python3.11'
-        - '3.8':
-            python-version: 'Python3.8'
-    jobs:
-        - 'pull-request-{plone-version}-{py}'
-
-- project:
-    name: Pull requests on Plone 6.1 for python 3
-    plone-version:
-        - '6.1'
-    py:
-        - '3.11':
-            python-version: 'Python3.11'
-    jobs:
-        - 'pull-request-{plone-version}-{py}'
-
-- project:
-    name: Plone 5.2 jobs on python 2.7
-    jobs:
         - 'plone-5.2-python-2.7'
-
-- project:
-    name: Plone 5.2 jobs on python 3.x
-    plone-version:
-        - '5.2'
-    py:
-        - '3.8':
-            python-version: 'Python3.8'
-    jobs:
-        - 'plone-{plone-version}-python-{py}'
-
-- project:
-    name: Plone 6.0 jobs on python 3.x
-    plone-version:
-        - '6.0'
-    py:
-        - '3.11':
-            python-version: 'Python3.11'
-        - '3.8':
-            python-version: 'Python3.8'
-    jobs:
-        - 'plone-{plone-version}-python-{py}'
-
-- project:
-    name: Plone 6.1 jobs on python 3.x
-    plone-version:
-        - '6.1'
-    py:
-        - '3.11':
-            python-version: 'Python3.11'
-    jobs:
-        - 'plone-{plone-version}-python-{py}'
-
-- project:
-    name: Plone 5.2 jobs on python 2.7 (robot tests)
-    jobs:
         - 'plone-5.2-python-2.7-robot-chrome'
 
 - project:
-    name: Plone 5.2 jobs on python 3.x (robot tests)
+    name: Plone 5.2 on python 3.x
     plone-version:
         - '5.2'
     py:
@@ -141,10 +71,12 @@
     browser:
         - chrome
     jobs:
+        - 'pull-request-{plone-version}-{py}'
+        - 'plone-{plone-version}-python-{py}'
         - 'plone-{plone-version}-python-{py}-robot-{browser}'
 
 - project:
-    name: Plone 6.0 jobs on python 3.x (robot tests)
+    name: Plone 6.0 on python 3.x
     plone-version:
         - '6.0'
     py:
@@ -155,10 +87,12 @@
     browser:
         - chrome
     jobs:
+        - 'pull-request-{plone-version}-{py}'
+        - 'plone-{plone-version}-python-{py}'
         - 'plone-{plone-version}-python-{py}-robot-{browser}'
 
 - project:
-    name: Plone 6.1 jobs on python 3.x (robot tests)
+    name: Plone 6.1 on python 3.x
     plone-version:
         - '6.1'
     py:
@@ -167,7 +101,12 @@
     browser:
         - chrome
     jobs:
+        - 'pull-request-{plone-version}-{py}'
+        - 'plone-{plone-version}-python-{py}'
         - 'plone-{plone-version}-python-{py}-robot-{browser}'
+
+
+### CORE JOBS (SCHEDULED)
 
 - project:
     name: Plone 5.2 jobs on python 3.x (scheduled)
@@ -176,8 +115,11 @@
     py:
         - '3.7':
             python-version: 'Python3.7'
+    browser:
+        - chrome
     jobs:
-        - 'plone-{plone-version}-python-{py}-scheduled'
+      - 'plone-{plone-version}-python-{py}-scheduled'
+      - 'plone-{plone-version}-python-{py}-robot-{browser}-scheduled'
 
 - project:
     name: Plone 6.0 jobs on python 3.x (scheduled)
@@ -188,34 +130,13 @@
             python-version: 'Python3.10'
         - '3.9':
             python-version: 'Python3.9'
+    browser:
+        - chrome
     jobs:
         - 'plone-{plone-version}-python-{py}-scheduled'
-
-- project:
-    name: Plone 5.2 jobs on python 3.x (robot tests) (scheduled)
-    plone-version:
-        - '5.2'
-    py:
-        - '3.7':
-            python-version: 'Python3.7'
-    browser:
-        - chrome
-    jobs:
         - 'plone-{plone-version}-python-{py}-robot-{browser}-scheduled'
 
-- project:
-    name: Plone 6.0 jobs on python 3.x (robot tests) (scheduled)
-    plone-version:
-        - '6.0'
-    py:
-        - '3.10':
-            python-version: 'Python3.10'
-        - '3.9':
-            python-version: 'Python3.9'
-    browser:
-        - chrome
-    jobs:
-        - 'plone-{plone-version}-python-{py}-robot-{browser}-scheduled'
+### OTHER
 
 - project:
     name: Translations on Plone 5.2 for python 2.7


### PR DESCRIPTION
This way we run less jobs per PR, which would allow for more PRs to be tested.

The regular jobs will be kept but run on a weekly basis, to ensure that they still work.

Closes #328 

- [x] update mr.roboto to no longer add python 3.9/3.10 to a PR
- [x] this MR
- [x] disable PR jenkins jobs for 6.0 3.9/3.10
- [x] move regular jenkins jobs for 6.0 3.9/3.10 to a new tab, see [`Core schedules`](https://jenkins.plone.org/view/Core%20schedules/) (name up to debate and bike shedding 😄 )
- [x] make regular jobs for 6.0 3.9/3.10 run in a weekly basis