### PR TITLE
Make Python 3.10 the minimum for Plone 6.1

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -72,6 +72,8 @@
             python-version: 'Python3.12'
         - '3.11':
             python-version: 'Python3.11'
+        - '3.10':
+            python-version: 'Python3.11'
         - '3.8':
             python-version: 'Python3.8'
     browser:
@@ -79,12 +81,18 @@
     exclude:
         - plone-version: '6.1'
           py: '3.11'
+        - plone-version: '6.1'
+          py: '3.8'
         - plone-version: '6.0'
           py: '3.12'
+        - plone-version: '6.0'
+          py: '3.10'
         - plone-version: '5.2'
           py: '3.12'
         - plone-version: '5.2'
           py: '3.11'
+        - plone-version: '5.2'
+          py: '3.10'
     jobs:
         - 'pull-request-{plone-version}-{py}'
         - 'plone-{plone-version}-python-{py}'


### PR DESCRIPTION
Closes #353 

i.e. stop testing Plone 6.1 on Python 3.8 and Python 3.9.