### PR TITLE
Add path parameter to `--xml` option

### DIFF
--- a/jobs/scripts/plips.sh
+++ b/jobs/scripts/plips.sh
@@ -19,4 +19,4 @@ export PYTHONWARNINGS='ignore'
 export PLAYWRIGHT_BROWSERS_PATH='/home/jenkins/robot-browsers/'
 bin/rfbrowser init
 
-bin/test --xml --all
+bin/test --xml parts/test --all

--- a/jobs/scripts/pr-tests.sh
+++ b/jobs/scripts/pr-tests.sh
@@ -27,11 +27,16 @@ if [[ "${{PLONE_VERSION}}" == 6* ]]; then
   export PLAYWRIGHT_BROWSERS_PATH='/home/jenkins/robot-browsers/'
 
   bin/rfbrowser init
+  # All tests without Robot
+  bin/test --all --xml parts/test -t '!ONLYROBOT' || return_code="$?"
+  # All tests with Robot
+  bin/test --all --xml parts/test -t ONLYROBOT || return_code="$?"
+else
+  # All tests without Robot
+  bin/test --all --xml -t '!ONLYROBOT' || return_code="$?"
+  # All tests with Robot
+  bin/test --all --xml -t ONLYROBOT || return_code="$?"
 fi
-# All tests without Robot
-bin/test --all --xml -t '!ONLYROBOT' || return_code="$?"
-# All tests with Robot
-bin/test --all --xml -t ONLYROBOT || return_code="$?"
 
 if [ "$return_code" = "all_right" ]; then
     return_code="$?"

--- a/jobs/scripts/robot.sh
+++ b/jobs/scripts/robot.sh
@@ -18,5 +18,7 @@ if [[ "${{PLONE_VERSION}}" == 6* ]]; then
   export PLAYWRIGHT_BROWSERS_PATH='/home/jenkins/robot-browsers/'
 
   bin/rfbrowser init
+  bin/test -t ONLYROBOT --all --xml parts/test
+else
+  bin/test -t ONLYROBOT --all --xml
 fi
-bin/test -t ONLYROBOT --all --xml

--- a/jobs/scripts/tests.sh
+++ b/jobs/scripts/tests.sh
@@ -2,10 +2,16 @@
 set -x
 
 PYTHON_VERSION="{py}"
+PLONE_VERSION="{plone-version}"
 /srv/python${{PYTHON_VERSION}}/bin/python3 -m venv venv
 . venv/bin/activate
 
 pip install -r requirements.txt
 
 buildout buildout:git-clone-depth=1 -c buildout.cfg
-bin/test --xml
+
+if [[ "${{PLONE_VERSION}}" == 6* ]]; then
+  bin/test --xml parts/test
+else
+  bin/test --xml
+fi


### PR DESCRIPTION
Switching to +6.3 `zope.testrunner` means that the `--xml` paramter expects a path, rather than being a boolean flag as it used to be with `collective.xmltestreport`.

This has to go together with https://github.com/plone/buildout.coredev/pull/927 and https://github.com/plone/buildout.coredev/pull/928