### PR TITLE
fix alias for i18ndude command

### DIFF
--- a/jobs/scripts/translations.sh
+++ b/jobs/scripts/translations.sh
@@ -11,7 +11,7 @@ mkdir reports
 
 export PYTHONIOENCODING=utf-8
 
-alias i18ndude '../../../../../../bin/i18ndude'
+alias i18ndude='../../../../../../bin/i18ndude'
 
 i18ndude list -p plone > reports/plone.txt
 i18ndude list -p cmfeditions  > reports/cmfeditions.txt


### PR DESCRIPTION
The translations job is broken on jenkins, see:

https://jenkins.plone.org/view/Translations/job/plone-6.0-python-3.8-i18n/lastBuild/console

It reports that the `i18ndude` command does not exist. The error is when creating the alias, it's missing the `=` in the script.