### PR TITLE
handle volto translations jobs

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -143,9 +143,10 @@
       - "plone-{plone-version}-python-{py}-i18n-find-missing"
 
 - project:
-    name: Translations of Volto (16.x.x)
+    name: Translations of Volto
     branch:
       - "16.x.x"
+      - "17.x.x"
       - "main"
     python-version: "Python3.9"
     jobs:
@@ -232,7 +233,7 @@
 
     publishers:
       - custom-archive:
-          glob: "volto-18n-report.txt"
+          glob: "volto-i18n-report.txt"
 
     <<: *plone-basic
 

--- a/jobs/scripts/volto-i18n.sh
+++ b/jobs/scripts/volto-i18n.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 set -x
 
+VOLTO_BRANCH="{branch}"
+
 python -m venv venv
 . venv/bin/activate
 pip install i18ndude
 
 export PYTHONIOENCODING=utf-8
 
-cd locales
-i18ndude list -p volto > ../volto-18n-report.txt
+if [ "${{VOLTO_BRANCH}}" = "main" ]; then
+  path="packages/volto/locales"
+  parent_path="../../.."
+else
+  path="locales"
+  parent_path=".."
+fi
+
+cd ${{path}}
+i18ndude list -p volto > ${{parent_path}}/volto-i18n-report.txt


### PR DESCRIPTION
We need specific jobs for each branch, because in 16.x.x and 17.x.x Volto lives in the root of the repo and in main it lives in `packages/volto`

Addresses https://github.com/plone/jenkins.plone.org/commit/3a5eb9e3b2e82843b38b49d4ea780f0dafb90725#commitcomment-145590810