### PR TITLE
Run Plone 6.0 Python 3.13 as core job.

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -84,15 +84,17 @@
       - chrome
     exclude:
       - plone-version: "6.1"
+        py: "3.12"
+      - plone-version: "6.1"
         py: "3.11"
       - plone-version: "6.1"
         py: "3.9"
       - plone-version: "6.1"
         py: "3.8"
       - plone-version: "6.0"
-        py: "3.13"
-      - plone-version: "6.0"
         py: "3.12"
+      - plone-version: "6.0"
+        py: "3.11"
       - plone-version: "6.0"
         py: "3.10"
       - plone-version: "6.0"
@@ -120,33 +122,17 @@
       - "6.1"
       - "6.0"
     py:
-      - "3.13":
-          python-version: "Python3.13"
       - "3.12":
           python-version: "Python3.12"
       - "3.11":
           python-version: "Python3.11"
       - "3.10":
           python-version: "Python3.10"
-      - "3.9":
-          python-version: "Python3.9"
     browser:
       - chrome
     exclude:
       - plone-version: "6.1"
-        py: "3.13"
-      - plone-version: "6.1"
-        py: "3.12"
-      - plone-version: "6.1"
         py: "3.10"
-      - plone-version: "6.1"
-        py: "3.9"
-      - plone-version: "6.0"
-        py: "3.13"
-      - plone-version: "6.0"
-        py: "3.11"
-      - plone-version: "6.0"
-        py: "3.9"
     jobs:
       - "plone-{plone-version}-python-{py}-scheduled"
       - "plone-{plone-version}-python-{py}-robot-{browser}-scheduled"


### PR DESCRIPTION
Core jobs would be (ignoring 5.2):

* 6.0: 3.9 and 3.13
* 6.1: 3.10 and 3.13

Core schedules would be:

* 6.0: 3.10, 3.11, 3.12
* 6.1: 3.11 and 3.12

See https://github.com/plone/jenkins.plone.org/pull/377#issuecomment-2531353597