### PR TITLE
Define core Python 3.14 jobs for Plone 6.2.

### DIFF
--- a/jobs/jobs.yml
+++ b/jobs/jobs.yml
@@ -61,6 +61,8 @@
       - "6.1"
       - "6.0"
     py:
+      - "3.14":
+          python-version: "Python3.14"
       - "3.13":
           python-version: "Python3.13"
       - "3.12":
@@ -75,17 +77,23 @@
       - chrome
     exclude:
       - plone-version: "6.2"
+        py: "3.13"
+      - plone-version: "6.2"
         py: "3.12"
       - plone-version: "6.2"
         py: "3.11"
       - plone-version: "6.2"
         py: "3.9"
       - plone-version: "6.1"
+        py: "3.14"
+      - plone-version: "6.1"
         py: "3.12"
       - plone-version: "6.1"
         py: "3.11"
       - plone-version: "6.1"
         py: "3.9"
+      - plone-version: "6.0"
+        py: "3.14"
       - plone-version: "6.0"
         py: "3.12"
       - plone-version: "6.0"
@@ -106,8 +114,8 @@
       - "6.1"
       - "6.0"
     py:
-      - "3.14":
-          python-version: "Python3.14"
+      - "3.13":
+          python-version: "Python3.13"
       - "3.12":
           python-version: "Python3.12"
       - "3.11":
@@ -121,8 +129,10 @@
         py: "3.10"
       - plone-version: "6.1"
         py: "3.10"
+      - plone-version: "6.1"
+        py: "3.13"
       - plone-version: "6.0"
-        py: "3.14"
+        py: "3.13"
     jobs:
       - "plone-{plone-version}-python-{py}-scheduled"
       - "plone-{plone-version}-python-{py}-robot-{browser}-scheduled"


### PR DESCRIPTION
* No longer have 6.2-3.14 only in the scheduled jobs.
* Instead, make 6.2-3.13 a scheduled job.
* Don't run combo of Plone 6.1 and Python 3.14 in scheduled jobs.

On GHA the 6.2-3.14 tests pass: https://github.com/plone/buildout.coredev/pull/1072
So this should be fine.  But all nodes need a proper Python 3.14, which I fear is not yet the case.  And the mr.roboto config on the server may need an update.
See also https://github.com/plone/jenkins.plone.org/issues/384
